### PR TITLE
backport fix for JDK-8150475

### DIFF
--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -15,7 +15,7 @@
   <name>error-prone javac</name>
   <groupId>com.google.errorprone</groupId>
   <artifactId>javac</artifactId>
-  <version>1.9.0-dev-r2973-2</version>
+  <version>1.9.0-dev-r2973-3</version>
   <packaging>jar</packaging>
 
   <description>A repackaged copy of javac for error-prone to depend on</description>

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
@@ -396,7 +396,7 @@ public class JavacFileManager extends BaseFileManager implements StandardJavaFil
             if (container.endsWith("bootmodules.jimage")) {
                 System.err.println("Warning: reference to bootmodules.jimage replaced by jrt:");
                 container = Locations.JRT_MARKER_FILE;
-            } else if (container.getFileName().toString().endsWith(".jimage")) {
+            } else if (container.getNameCount() > 0 && container.getFileName().toString().endsWith(".jimage")) {
                 System.err.println("Warning: reference to " + container + " ignored");
                 return;
             }

--- a/test/tools/javac/file/T8150475.java
+++ b/test/tools/javac/file/T8150475.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @compile -sourcepath / T8150475.java
+ */
+
+class T8150475 { }


### PR DESCRIPTION
See https://github.com/google/error-prone/issues/451: backport http://hg.openjdk.java.net/jdk9/jdk9/langtools/rev/21d9e172e9f6
